### PR TITLE
Add sample tvOS Stremio client

### DIFF
--- a/StremioTV/Package.swift
+++ b/StremioTV/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "StremioTV",
+    platforms: [ .tvOS(.v15) ],
+    products: [
+        .executable(name: "StremioTVApp", targets: ["StremioTVApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Stremio/stremio-core-swift", from: "1.2.62")
+    ],
+    targets: [
+        .executableTarget(
+            name: "StremioTVApp",
+            dependencies: [
+                .product(name: "StremioCore", package: "stremio-core-swift")
+            ],
+            path: "Sources/StremioTVApp"
+        )
+    ]
+)

--- a/StremioTV/README.md
+++ b/StremioTV/README.md
@@ -1,0 +1,12 @@
+# StremioTV
+
+This directory contains a sample tvOS application that integrates with the [Stremio Core Swift](https://github.com/Stremio/stremio-core-swift) library. The goal is to provide a starting point for building a native Stremio client for Apple TV.
+
+The sample uses SwiftUI and targets tvOS 15+. It fetches catalogs from official Stremio add-ons and allows basic playback using `AVPlayer`.
+
+## Structure
+- `Package.swift` – Swift Package configuration referencing `StremioCore` as a dependency.
+- `Sources/StremioTVApp/StremioTVApp.swift` – Application entry point.
+- `Sources/StremioTVApp/ContentView.swift` – Minimal UI that lists trending movies.
+
+To build the app open this folder in Xcode and run on a tvOS simulator or device.

--- a/StremioTV/Sources/StremioTVApp/ContentView.swift
+++ b/StremioTV/Sources/StremioTVApp/ContentView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import StremioCore
+import AVKit
+
+struct CatalogItem: Identifiable {
+    let id: String
+    let name: String
+    let poster: URL?
+    let stream: String
+}
+
+struct ContentView: View {
+    @State private var items: [CatalogItem] = []
+    @State private var player: AVPlayer? = nil
+
+    var body: some View {
+        NavigationStack {
+            List(items) { item in
+                Button(action: { play(stream: item.stream) }) {
+                    HStack {
+                        AsyncImage(url: item.poster)
+                            .frame(width: 100, height: 150)
+                        Text(item.name)
+                    }
+                }
+            }
+            .navigationTitle("Trending")
+            .task { await loadCatalog() }
+            .fullScreenCover(item: $player) { player in
+                VideoPlayer(player: player)
+                    .onDisappear { player.pause() }
+            }
+        }
+    }
+
+    func loadCatalog() async {
+        // Example call to get catalog using Stremio Core
+        guard let action = try? Stremio_Core_Runtime_Action.with { builder in
+            var catalogReq = Stremio_Core_Types_CatalogRequest()
+            catalogReq.type = "movie"
+            catalogReq.id = "top"
+            builder.requests = [catalogReq]
+        } else { return }
+        Core.dispatch(action: action)
+
+        if let state: Stremio_Core_Runtime_State = Core.getState(.context) {
+            items = state.catalog.items.map { it in
+                CatalogItem(
+                    id: it.id,
+                    name: it.name,
+                    poster: URL(string: it.poster),
+                    stream: it.stream)
+            }
+        }
+    }
+
+    func play(stream: String) {
+        if let url = URL(string: stream) {
+            player = AVPlayer(url: url)
+            player?.play()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/StremioTV/Sources/StremioTVApp/StremioTVApp.swift
+++ b/StremioTV/Sources/StremioTVApp/StremioTVApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import StremioCore
+import AVKit
+
+@main
+struct StremioTVApp: App {
+    init() {
+        // Initialize Stremio Core at app launch
+        _ = Core.initialize()
+    }
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up `StremioTV` as a minimal tvOS SwiftUI app
- reference `stremio-core-swift` via Swift Package Manager
- show a simple `ContentView` listing trending movies

## Testing
- `swift build` *(fails: Generating swift files from proto files failed: unable to spawn process '/$SRCROOT/Support/protoc' (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_6841b70ea14483239fb901003e5b5f9f